### PR TITLE
Apply setMaxLifecycle during fragment transaction & update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,9 @@ cache:
 
 android:
   components:
-    # use the latest revision of Android SDK Tools
     - tools
     - platform-tools
-    - tools
-    # The BuildTools version used by your project
-    - build-tools-27.0.3
-    # The SDK version used to compile your project
-    - android-27
-    # Additional components
+    - tool
     - extra-google-m2repository
     - extra-android-m2repository
     - extra-android-support
@@ -29,41 +23,10 @@ android:
     - 'google-gdk-license-.+'
 
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 notifications:
   email: false
-
-install:
-  # List and delete unnecessary components to free space
-  - sdkmanager --list || true
-  - sdkmanager --uninstall "system-images;android-15;default;armeabi-v7a"
-  - sdkmanager --uninstall "system-images;android-16;default;armeabi-v7a"
-  - sdkmanager --uninstall "system-images;android-17;default;armeabi-v7a"
-  - sdkmanager --uninstall "system-images;android-18;default;armeabi-v7a"
-  - sdkmanager --uninstall "system-images;android-19;default;armeabi-v7a"
-  - sdkmanager --uninstall "system-images;android-21;default;armeabi-v7a"
-  - sdkmanager --uninstall "extras;google;google_play_services"
-  - sdkmanager --uninstall "extras;android;support"
-  - sdkmanager --uninstall "platforms;android-10"
-  - sdkmanager --uninstall "platforms;android-15"
-  - sdkmanager --uninstall "platforms;android-16"
-  - sdkmanager --uninstall "platforms;android-17"
-  - sdkmanager --uninstall "platforms;android-18"
-  - sdkmanager --uninstall "platforms;android-19"
-  - sdkmanager --uninstall "platforms;android-20"
-  - sdkmanager --uninstall "platforms;android-21"
-  - sdkmanager --uninstall "platforms;android-22"
-  - sdkmanager --uninstall "platforms;android-23"
-  - sdkmanager --uninstall "platforms;android-24"
-  - sdkmanager --uninstall "platforms;android-25"
-  - sdkmanager --uninstall "platforms;android-26"
-  - sdkmanager --uninstall "build-tools;25.0.2"
-  # Update sdk tools to latest version and install/update components
-  - echo yes | sdkmanager "tools"
-  - echo yes | sdkmanager "platforms;android-27" # Latest platform required by SDK tools
-  - echo yes | sdkmanager "extras;android;m2repository"
-  - echo yes | sdkmanager "extras;google;m2repository"
 
 script:
   - ./gradlew jacocoTestReportDebug coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
+os: linux
 language: android
+jdk: oraclejdk11
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -7,14 +10,18 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
-
-android:
-  components:
-    - tools
-    - platform-tools
-
-jdk:
-  - oraclejdk11
+    
+env:
+  global:
+    - TARGET_VERSION=31
+    - ANDROID_BUILD_TOOLS_VERSION=30.0.2
+    - ANDROID_HOME=~/android-sdk
+    
+before_install:
+  - touch $HOME/.android/repositories.cfg
+  - wget "https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip" -O commandlinetools.zip
+  - unzip commandlinetools.zip -d $ANDROID_HOME/
+  - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --licenses
 
 notifications:
   email: false
@@ -22,6 +29,3 @@ notifications:
 script:
   - ./gradlew jacocoTestReportDebug coveralls
 
-install:
-- echo yes | sdkmanager "tools"
-- echo yes | sdkmanager "platforms;android-31"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,10 @@ cache:
     
 env:
   global:
-    - TARGET_VERSION=31
-    - ANDROID_BUILD_TOOLS_VERSION=30.0.2
     - ANDROID_HOME=~/android-sdk
     
 before_install:
-  - touch $HOME/.android/repositories.cfg
-  - wget "https://dl.google.com/android/repository/commandlinetools-linux-7302050_latest.zip" -O commandlinetools.zip
+  - wget "https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip" -O commandlinetools.zip
   - unzip commandlinetools.zip -d $ANDROID_HOME/
   - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_HOME
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     
 before_install:
   - touch $HOME/.android/repositories.cfg
-  - wget "https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip" -O commandlinetools.zip
+  - wget "https://dl.google.com/android/repository/commandlinetools-linux-7302050_latest.zip" -O commandlinetools.zip
   - unzip commandlinetools.zip -d $ANDROID_HOME/
   - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --licenses
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ android:
     - 'google-gdk-license-.+'
 
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,6 @@ android:
   components:
     - tools
     - platform-tools
-    - tool
-    - extra-google-m2repository
-    - extra-android-m2repository
-    - extra-android-support
-
-  licenses:
-    - 'android-sdk-preview-license-.+'
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
 
 jdk:
   - oraclejdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ script:
   - ./gradlew jacocoTestReportDebug coveralls
 
 install:
-- yes | sdkmanager --licenses
+- echo yes | sdkmanager "tools"
+- echo yes | sdkmanager "platforms;android-31"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ before_install:
   - touch $HOME/.android/repositories.cfg
   - wget "https://dl.google.com/android/repository/commandlinetools-linux-7302050_latest.zip" -O commandlinetools.zip
   - unzip commandlinetools.zip -d $ANDROID_HOME/
-  - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --licenses
-
+  - yes | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --licenses --sdk_root=$ANDROID_HOME
+  
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,6 @@ notifications:
 
 script:
   - ./gradlew jacocoTestReportDebug coveralls
+
+install:
+- yes | sdkmanager --licenses

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ While having a good architecture and caching most of the data that is presented 
 
   This gives the best performance keeping all fragments in the memory so we won't have to wait for the rebuilding of them. However with many tabs and deep navigation stacks this can lead easily to memory consumption issues.
 
+**WARNING** - Keep in mind that using **show and hide does not trigger the usual lifecycle events** of the fragments so app developer has to manually take care of handling state which is usually done in the Fragment onPause/Stop and onResume/Start methods. But you can enable *setMaxLifecycleOnSwitch* to force fragments triggering usual lifecycle events, and it's done on the fragment transaction while switching tabs.
+
 ```java
 mNavController = FragNavController.newBuilder(...)
                 ...

--- a/README.md
+++ b/README.md
@@ -224,8 +224,6 @@ While having a good architecture and caching most of the data that is presented 
 
   This gives the best performance keeping all fragments in the memory so we won't have to wait for the rebuilding of them. However with many tabs and deep navigation stacks this can lead easily to memory consumption issues.
 
-**WARNING** - Keep in mind that using **show and hide does not trigger the usual lifecycle events** of the fragments so app developer has to manually take care of handling state which is usually done in the Fragment onPause/Stop and onResume/Start methods.
-
 ```java
 mNavController = FragNavController.newBuilder(...)
                 ...

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,14 @@ android {
     }
 }
 
+repositories {
+    repositories {
+        google()
+        jcenter()
+        mavenCentral()
+    }
+}
+
 dependencies {
     implementation project(':frag-nav')
     implementation "com.google.android.material:material:1.5.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,14 +21,11 @@ android {
         }
     }
 }
-repositories {
-    jcenter()
-}
 
 dependencies {
     implementation project(':frag-nav')
-    implementation "com.google.android.material:material:1.0.0"
-    implementation "androidx.appcompat:appcompat:1.0.2"
+    implementation "com.google.android.material:material:1.5.0"
+    implementation "androidx.appcompat:appcompat:1.4.1"
     implementation "com.roughike:bottom-bar:2.3.1"
     testImplementation "junit:junit:$rootProject.ext.junitVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name=".activities.MainActivity">
+        <activity android:name=".activities.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/BottomTabsActivity.kt
@@ -1,11 +1,11 @@
 package com.ncapdevi.sample.activities
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
-import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import com.ncapdevi.fragnav.FragNavController
 import com.ncapdevi.fragnav.FragNavLogger
 import com.ncapdevi.fragnav.FragNavSwitchController
@@ -74,9 +74,9 @@ class BottomTabsActivity : AppCompatActivity(), BaseFragment.FragmentNavigation,
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle?) {
+    override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        fragNavController.onSaveInstanceState(outState!!)
+        fragNavController.onSaveInstanceState(outState)
 
     }
 

--- a/app/src/main/java/com/ncapdevi/sample/activities/NavDrawerActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/NavDrawerActivity.kt
@@ -1,15 +1,15 @@
 package com.ncapdevi.sample.activities
 
 import android.os.Bundle
-import com.google.android.material.navigation.NavigationView
-import androidx.fragment.app.Fragment
-import androidx.core.view.GravityCompat
-import androidx.drawerlayout.widget.DrawerLayout
+import android.view.MenuItem
+import android.view.View
 import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import android.view.MenuItem
-import android.view.View
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
+import androidx.fragment.app.Fragment
+import com.google.android.material.navigation.NavigationView
 import com.ncapdevi.fragnav.FragNavController
 import com.ncapdevi.fragnav.FragNavTransactionOptions
 import com.ncapdevi.sample.R
@@ -71,7 +71,7 @@ class NavDrawerActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle?) {
+    override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         fragNavController.onSaveInstanceState(outState)
     }

--- a/app/src/main/java/com/ncapdevi/sample/activities/NavDrawerActivity.kt
+++ b/app/src/main/java/com/ncapdevi/sample/activities/NavDrawerActivity.kt
@@ -96,7 +96,7 @@ class NavDrawerActivity : AppCompatActivity(), NavigationView.OnNavigationItemSe
         return true
     }
 
-    override fun pushFragment(fragment: Fragment, sharedList: List<Pair<View, String>>?) {
+    override fun pushFragment(fragment: Fragment, sharedElementList: List<Pair<View, String>>?) {
         fragNavController.pushFragment(fragment)
     }
 }

--- a/app/src/main/java/com/ncapdevi/sample/fragments/BaseFragment.kt
+++ b/app/src/main/java/com/ncapdevi/sample/fragments/BaseFragment.kt
@@ -2,12 +2,11 @@ package com.ncapdevi.sample.fragments
 
 import android.content.Context
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-
+import androidx.fragment.app.Fragment
 import com.ncapdevi.sample.R
 
 /**
@@ -34,7 +33,7 @@ open class BaseFragment : Fragment() {
         }
     }
 
-    override fun onAttach(context: Context?) {
+    override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context is FragmentNavigation) {
             mFragmentNavigation = context

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0"
-        classpath "org.jacoco:org.jacoco.core:0.8.3"
+        classpath "org.jacoco:org.jacoco.core:0.8.7"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
-    ext.kotlin_version = '1.3.31'
-    ext.spek_version = '2.0.0-rc.1'
+    ext.kotlin_version = '1.6.10'
+    ext.spek_version = '2.0.18'
     repositories {
         jcenter()
         google()
-
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.3.1.1"
-        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.13.0"
+        classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0"
+        classpath "org.jacoco:org.jacoco.core:0.8.3"
     }
 }
 
@@ -19,24 +19,25 @@ allprojects {
         google()
         jcenter()
         mavenCentral()
-        maven { url "http://dl.bintray.com/jetbrains/spek" }
     }
 }
+
 repositories {
     google()
-    jcenter()
     mavenCentral()
 }
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
 ext {
-    // App dependencies
+    localProperties = null
 
-    junitVersion = '4.12'
-    buildToolsVersion = '28.0.3'
+    // App dependencies
+    junitVersion = '4.13.2'
+    buildToolsVersion = '30.0.3'
     minSdkVersion = 14
-    targetSdkVersion = 28
-    compileSdkVersion = 28
+    targetSdkVersion = 31
+    compileSdkVersion = 31
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     ext.kotlin_version = '1.6.10'
     ext.spek_version = '2.0.18'
     repositories {
-        jcenter()
         google()
         mavenCentral()
     }
@@ -17,7 +16,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         mavenCentral()
     }
 }
@@ -32,8 +30,6 @@ task clean(type: Delete) {
 }
 
 ext {
-    localProperties = null
-
     // App dependencies
     junitVersion = '4.13.2'
     buildToolsVersion = '30.0.3'

--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -1,15 +1,14 @@
 plugins {
     id "com.jfrog.bintray" version "1.8.4"
-    id "com.github.dcendents.android-maven" version "2.1"
-    id 'com.github.kt3k.coveralls' version '2.8.2'
+    id 'com.github.kt3k.coveralls' version '2.12.0'
 }
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'jacoco'
 apply plugin: "de.mannodermaus.android-junit5"
-apply plugin: "com.vanniktech.android.junit.jacoco"
 
 ext {
     libraryVersionCode = 30
@@ -71,6 +70,15 @@ android {
                     include 'spek2'
                 }
             }
+            jacocoOptions {
+                // here goes all jacoco config, for example
+                html.enabled = true
+                xml.enabled = false
+                csv.enabled = false
+                unitTests.all {
+                    testLogging.events = ["passed", "skipped", "failed"]
+                }
+            }
         }
     }
 }
@@ -78,17 +86,16 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "androidx.fragment:fragment:1.0.0"
-    implementation "androidx.annotation:annotation:1.0.2"
+    implementation "androidx.fragment:fragment-ktx:1.4.1"
+    implementation "androidx.annotation:annotation:1.3.0"
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0"
-    testImplementation "org.robolectric:robolectric:4.0.2"
+    testImplementation "org.robolectric:robolectric:4.2"
 
     testImplementation 'org.amshove.kluent:kluent-android:1.42'
 
     // Spek
-
     testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
     testImplementation "org.spekframework.spek2:spek-runner-junit5:$spek_version"
     testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
@@ -99,102 +106,64 @@ dependencies {
         exclude group: 'org.junit.platform'
         exclude group: 'org.jetbrains.kotlin'
     }
-
-
 }
 
-group = publishedGroupId                               // Maven Group ID for the artifact
+group = publishedGroupId
+version = libraryVersionName
 
-install {
-    repositories.mavenInstaller {
-        // This generates POM.xml with proper parameters
-        pom {
-            project {
-                packaging 'aar'
-                groupId publishedGroupId
-                artifactId artifact
+Object getBuildProperty(String varName, String defaultValue = null) {
+    if (System.getenv().containsKey(varName)) {
+        return System.getenv()[varName]
+    }
 
-                // Add your description here
-                name libraryName
-                description libraryDescription
-                url siteUrl
+    // read local.properties only once and cache properties
+    if (rootProject.ext.localProperties == null) {
+        File propsFile = file(rootProject.file('local.properties'))
+        rootProject.ext.localProperties = new Properties()
+        if (propsFile.exists() && propsFile.canRead()) {
+            rootProject.ext.localProperties.load(new FileInputStream(propsFile))
+        }
+    }
 
-                // Set your license
-                licenses {
-                    license {
-                        name licenseName
-                        url licenseUrl
-                    }
-                }
-                developers {
-                    developer {
-                        id developerId
-                        name developerName
-                        email developerEmail
-                    }
-                }
-                scm {
-                    connection gitUrl
-                    developerConnection gitUrl
-                    url siteUrl
+    if (rootProject.ext.localProperties.containsKey(varName)) {
+        return rootProject.ext.localProperties[varName]
+    }
 
-                }
+    if (rootProject.hasProperty(varName)) {
+        return rootProject.property(varName)
+    }
+
+    return defaultValue
+}
+
+afterEvaluate {
+
+    tasks.register("sourcesJar", Jar) {
+        from android.sourceSets.main.java.srcDirs
+        classifier = 'sources'
+    }
+
+    publishing {
+        publications {
+            aar(MavenPublication) {
+                artifact sourcesJar
+                from components.release
+                version = project.version
             }
         }
     }
-}
 
-
-version = libraryVersionName
-
-if (project.hasProperty("android")) { // Android libraries
-    task sourcesJar(type: Jar) {
-        classifier = 'sources'
-        from android.sourceSets.main.java.srcDirs
-    }
-
-/*    task javadoc(type: Javadoc) {
-        source = android.sourceSets.main.java.srcDirs
-        classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    }*/
-} else { // Java libraries
-    task sourcesJar(type: Jar, dependsOn: classes) {
-        classifier = 'sources'
-        from sourceSets.main.allSource
-    }
-}
-
-/*task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}*/
-
-artifacts {
-    // archives javadocJar
-    archives sourcesJar
-}
-
-// Bintray
-bintray {
-    Properties properties = new Properties()
-    if (project.rootProject.file('local.properties').exists()) {
-        properties.load(project.rootProject.file('local.properties').newDataInputStream())
-
-        user = properties.getProperty("bintray.user")
-        key = properties.getProperty("bintray.apikey")
-
-        configurations = ['archives']
-        pkg {
-            repo = bintrayRepo
-            name = bintrayName
-            desc = libraryDescription
-            websiteUrl = siteUrl
-            vcsUrl = gitUrl
-            licenses = allLicenses
-            publish = true
-            publicDownloadNumbers = true
-            version {
-                desc = libraryDescription
+    publishing {
+        repositories {
+            maven {
+                def contextUrl = getBuildProperty('ARTIFACTORY_CONTEXT_URL')
+                def repoKey = getBuildProperty('ARTIFACTORY_REPO_KEY')
+                // change to point to your repo, e.g. http://my.org/repo
+                url = "$contextUrl/$repoKey"
+                credentials {
+                    username getBuildProperty('ARTIFACTORY_PUBLISH_USERNAME')
+                    password getBuildProperty('ARTIFACTORY_PUBLISH_PASSWORD')
+                }
             }
         }
     }
@@ -207,39 +176,4 @@ coveralls {
 tasks.coveralls {
     dependsOn 'jacocoTestReportDebug'
     onlyIf { System.env.'CI' }
-}
-task createPom {
-    pom {
-        project {
-            packaging 'aar'
-
-            name project.name
-            description libraryDescription
-            url siteUrl
-            inceptionYear '2016'
-
-            licenses {
-                license {
-                    name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                }
-            }
-            scm {
-                connection gitUrl
-                developerConnection gitUrl
-                url siteUrl
-            }
-            developers {
-                developer {
-                    id 'ncapdevi'
-                    name 'Nic Capdevila'
-                    email 'ncapdevi@gmail.com'
-                }
-            }
-        }
-    }.writeTo("$buildDir/poms/pom-default.xml").writeTo("pom.xml")
-}
-build.dependsOn createPom
-repositories {
-    mavenCentral()
 }

--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "com.jfrog.bintray" version "1.8.4"
     id 'com.github.kt3k.coveralls' version '2.12.0'
 }
 
@@ -10,32 +9,8 @@ apply plugin: 'com.github.kt3k.coveralls'
 apply plugin: 'jacoco'
 apply plugin: "de.mannodermaus.android-junit5"
 
-ext {
-    libraryVersionCode = 30
-    libraryVersionName = '3.3.0'
-
-    //Bintray and Maven
-    bintrayRepo = 'maven'
-    bintrayName = 'frag-nav'
-
-    publishedGroupId = 'com.ncapdevi'
-    libraryName = 'FragNav'
-    artifact = 'frag-nav'
-
-    libraryDescription = 'A library to help manage multiple fragment stacks'
-
-    siteUrl = 'https://github.com/ncapdevi/FragNav'
-    gitUrl = 'https://github.com/ncapdevi/FragNav.git'
-
-    developerId = 'ncapdevi'
-    developerName = 'Nic Capdevila'
-    developerEmail = 'ncapdevi@gmail.com'
-
-    licenseName = 'The Apache Software License, Version 2.0'
-    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-    allLicenses = ["Apache-2.0"]
-}
-
+group = 'com.ncapdevi'
+version = '3.3.0-apply-max-lifecycle'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -47,8 +22,8 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.compileSdkVersion
-        versionCode libraryVersionCode
-        versionName libraryVersionName
+        versionCode 30
+        versionName version
     }
     buildTypes {
         release {
@@ -71,7 +46,6 @@ android {
                 }
             }
             jacocoOptions {
-                // here goes all jacoco config, for example
                 html.enabled = true
                 xml.enabled = false
                 csv.enabled = false
@@ -81,19 +55,26 @@ android {
             }
         }
     }
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "androidx.fragment:fragment-ktx:1.4.1"
+    implementation "androidx.fragment:fragment:1.4.1"
     implementation "androidx.annotation:annotation:1.3.0"
 
     testImplementation "junit:junit:$rootProject.ext.junitVersion"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0"
     testImplementation "org.robolectric:robolectric:4.2"
 
-    testImplementation 'org.amshove.kluent:kluent-android:1.42'
+    testImplementation 'org.amshove.kluent:kluent-android:1.65'
 
     // Spek
     testImplementation "org.spekframework.spek2:spek-dsl-jvm:$spek_version"
@@ -106,34 +87,6 @@ dependencies {
         exclude group: 'org.junit.platform'
         exclude group: 'org.jetbrains.kotlin'
     }
-}
-
-group = publishedGroupId
-version = libraryVersionName
-
-Object getBuildProperty(String varName, String defaultValue = null) {
-    if (System.getenv().containsKey(varName)) {
-        return System.getenv()[varName]
-    }
-
-    // read local.properties only once and cache properties
-    if (rootProject.ext.localProperties == null) {
-        File propsFile = file(rootProject.file('local.properties'))
-        rootProject.ext.localProperties = new Properties()
-        if (propsFile.exists() && propsFile.canRead()) {
-            rootProject.ext.localProperties.load(new FileInputStream(propsFile))
-        }
-    }
-
-    if (rootProject.ext.localProperties.containsKey(varName)) {
-        return rootProject.ext.localProperties[varName]
-    }
-
-    if (rootProject.hasProperty(varName)) {
-        return rootProject.property(varName)
-    }
-
-    return defaultValue
 }
 
 afterEvaluate {
@@ -149,6 +102,25 @@ afterEvaluate {
                 artifact sourcesJar
                 from components.release
                 version = project.version
+
+                pom {
+                    name = 'FragNav'
+                    description = 'A library to help manage multiple fragment stacks'
+                    url = 'https://github.com/ncapdevi/FragNav'
+                    licenses {
+                        license {
+                            name = 'The Apache Software License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'ncapdevi'
+                            name = 'Nic Capdevila'
+                            email = 'ncapdevi@gmail.com'
+                        }
+                    }
+                }
             }
         }
     }
@@ -156,14 +128,11 @@ afterEvaluate {
     publishing {
         repositories {
             maven {
-                def contextUrl = getBuildProperty('ARTIFACTORY_CONTEXT_URL')
-                def repoKey = getBuildProperty('ARTIFACTORY_REPO_KEY')
-                // change to point to your repo, e.g. http://my.org/repo
-                url = "$contextUrl/$repoKey"
-                credentials {
-                    username getBuildProperty('ARTIFACTORY_PUBLISH_USERNAME')
-                    password getBuildProperty('ARTIFACTORY_PUBLISH_PASSWORD')
-                }
+                url = rootProject.properties['publishRepoUrl'].toString()
+                name = "publishRepo"
+
+                // https://docs.gradle.org/current/samples/sample_publishing_credentials.html
+                credentials(PasswordCredentials)
             }
         }
     }

--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -131,7 +131,7 @@ afterEvaluate {
 }
 
 coveralls {
-    jacocoReportPath = "${buildDir}/reports/jacoco/debug/jacoco.xml"
+    jacocoReportPath = "${buildDir}/reports/jacoco/jacocoTestReportDebug/jacocoTestReportDebug.xml"
 }
 
 tasks.coveralls {

--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -45,14 +45,6 @@ android {
                     include 'spek2'
                 }
             }
-            jacocoOptions {
-                html.enabled = true
-                xml.enabled = false
-                csv.enabled = false
-                unitTests.all {
-                    testLogging.events = ["passed", "skipped", "failed"]
-                }
-            }
         }
     }
 

--- a/frag-nav/build.gradle
+++ b/frag-nav/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'jacoco'
 apply plugin: "de.mannodermaus.android-junit5"
 
 group = 'com.ncapdevi'
-version = '3.3.0-apply-max-lifecycle'
+version = '3.3.0-max-lifecycle-option'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -65,7 +65,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation "androidx.fragment:fragment:1.4.1"
     implementation "androidx.annotation:annotation:1.3.0"

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -691,11 +691,8 @@ class FragNavController constructor(private val fragmentManger: FragmentManager,
 
                 setTransition(options.transition)
 
-                options.sharedElements.forEach { sharedElement ->
-                    addSharedElement(
-                        sharedElement.first,
-                        sharedElement.second
-                    )
+                options.sharedElements.forEach { (element, elementName) ->
+                    addSharedElement(element, elementName)
                 }
 
                 @Suppress("DEPRECATION")

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavController.kt
@@ -66,6 +66,13 @@ class FragNavController constructor(private val fragmentManger: FragmentManager,
     var fragmentHideStrategy = FragNavController.DETACH
     var createEager = false
 
+    /**
+     *  There's a known issue that if you use the hiding strategy on the fragment switch, the
+     *  fragment's lifecycle won't be changed. Set this flag to true will set the maximum
+     *  lifecycle state during the transaction, so the lifecycle will be triggered properly.
+     */
+    var setMaxLifecycleOnSwitch = false
+
     @TabIndex
     @get:CheckResult
     @get:TabIndex
@@ -221,7 +228,9 @@ class FragNavController constructor(private val fragmentManger: FragmentManager,
                         shouldDetachAttachOnSwitch() -> ft.detach(fragment)
                         shouldRemoveAttachOnSwitch() -> ft.remove(fragment)
                         else -> {
-                            ft.setMaxLifecycle(fragment, Lifecycle.State.STARTED)
+                            if (setMaxLifecycleOnSwitch) {
+                                ft.setMaxLifecycle(fragment, Lifecycle.State.STARTED)
+                            }
                             ft.hide(fragment)
                         }
                     }
@@ -282,7 +291,7 @@ class FragNavController constructor(private val fragmentManger: FragmentManager,
                 //Attempt to reattach previous fragment
                 fragment = addPreviousFragment(ft, shouldAttach)
 
-                if (!shouldAttach) {
+                if (!shouldAttach && setMaxLifecycleOnSwitch) {
                     fragmentCache.values.forEach { ref ->
                         val frag = ref.get() ?: return@forEach
                         ft.setMaxLifecycle(frag, Lifecycle.State.STARTED)

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavTransactionOptions.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/FragNavTransactionOptions.kt
@@ -1,9 +1,9 @@
 package com.ncapdevi.fragnav
 
+import android.view.View
 import androidx.annotation.AnimRes
 import androidx.annotation.StyleRes
 import androidx.fragment.app.FragmentTransaction
-import android.view.View
 
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 class FragNavTransactionOptions private constructor(builder: Builder) {
@@ -19,8 +19,11 @@ class FragNavTransactionOptions private constructor(builder: Builder) {
     @AnimRes
     val popExitAnimation = builder.popExitAnimation
     @StyleRes
+    @Deprecated("https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction#setTransitionStyle(int)")
     val transitionStyle = builder.transitionStyle
+    @Deprecated("https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction#setBreadCrumbTitle(int)")
     val breadCrumbTitle: String? = builder.breadCrumbTitle
+    @Deprecated("https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction#setBreadCrumbShortTitle(int)")
     val breadCrumbShortTitle: String? = builder.breadCrumbShortTitle
     val allowStateLoss: Boolean = builder.allowStateLoss
     val reordering: Boolean = builder.reordering

--- a/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/FragNavTabHistoryController.kt
+++ b/frag-nav/src/main/java/com/ncapdevi/fragnav/tabhistory/FragNavTabHistoryController.kt
@@ -8,6 +8,7 @@ interface FragNavTabHistoryController {
     /**
      * Define what happens when we try to pop on a tab where root fragment is at the top
      */
+    @Suppress("DEPRECATION")
     @IntDef(CURRENT_TAB, UNIQUE_TAB_HISTORY, UNLIMITED_TAB_HISTORY)
     @kotlin.annotation.Retention(AnnotationRetention.SOURCE)
     annotation class PopStrategy

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerRaceConditionSpec.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerRaceConditionSpec.kt
@@ -168,7 +168,7 @@ class FakeFragmentTransaction(private val parent: FakeFragmentManager) {
 
     fun create(): FragmentTransaction {
         return mock {
-            on { add(any(), any(), any()) } doAnswer { invocationOnMock ->
+            on { add(any(), any<Fragment>(), any()) } doAnswer { invocationOnMock ->
                 pendingActions.add(Add(invocationOnMock.getArgument<Fragment>(1), invocationOnMock.getArgument<String>(2)))
                 this.mock
             }

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerRaceConditionSpec.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavControllerRaceConditionSpec.kt
@@ -212,6 +212,7 @@ class FakeFragmentTransaction(private val parent: FakeFragmentManager) {
                     is Remove -> parent.remove(it.fragment)
                     is Attach -> parent.attach(it.fragment)
                     is Detach -> parent.detach(it.fragment)
+                    else -> Unit
                 }
             }
             parent.operation(Commit)

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavTransactionOptionsTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/FragNavTransactionOptionsTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 
 class FragNavTransactionOptionsTest {
 
+    @Suppress("DEPRECATION")
     @Test
     fun buildTransactionOptions() {
         val breadCrumbShortTitle = "Short Title"

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryControllerTest.kt
@@ -5,8 +5,7 @@ import com.ncapdevi.fragnav.FragNavPopController
 import com.ncapdevi.fragnav.FragNavSwitchController
 import com.ncapdevi.fragnav.FragNavTransactionOptions
 import com.nhaarman.mockitokotlin2.*
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,7 +46,7 @@ class UniqueTabHistoryControllerTest {
         val result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
-        assert(result)
+        assertTrue(result)
         verify(mockFragNavSwitchController, never()).switchTab(any(), anyOrNull())
     }
 
@@ -74,7 +73,7 @@ class UniqueTabHistoryControllerTest {
         val result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
-        assert(result)
+        assertTrue(result)
         verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions))
     }
 
@@ -89,7 +88,7 @@ class UniqueTabHistoryControllerTest {
         val result = uniqueTabHistoryController.popFragments(2, mockTransactionOptions)
 
         // Then
-        assert(result)
+        assertTrue(result)
         verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions))
     }
 
@@ -120,7 +119,7 @@ class UniqueTabHistoryControllerTest {
         val result = uniqueTabHistoryController.popFragments(15, mockTransactionOptions)
 
         // Then
-        assert(result)
+        assertTrue(result)
         argumentCaptor<Int>().apply {
             verify(mockFragNavSwitchController, times(4)).switchTab(capture(), eq(mockTransactionOptions))
 
@@ -147,7 +146,7 @@ class UniqueTabHistoryControllerTest {
 
         // When
         for (i in 0..3) {
-            assert(uniqueTabHistoryController.popFragments(1, mockTransactionOptions))
+            assertTrue(uniqueTabHistoryController.popFragments(1, mockTransactionOptions))
         }
         assertFalse(uniqueTabHistoryController.popFragments(1, mockTransactionOptions))
 
@@ -176,7 +175,7 @@ class UniqueTabHistoryControllerTest {
         mockNavSwitchController(newUniqueTabHistoryController)
         newUniqueTabHistoryController.restoreFromBundle(mockBundle)
         for (i in 0..3) {
-            assert(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions))
+            assertTrue(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions))
         }
 
         // Then

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UniqueTabHistoryControllerTest.kt
@@ -5,13 +5,13 @@ import com.ncapdevi.fragnav.FragNavPopController
 import com.ncapdevi.fragnav.FragNavSwitchController
 import com.ncapdevi.fragnav.FragNavTransactionOptions
 import com.nhaarman.mockitokotlin2.*
-import junit.framework.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
-import java.util.*
 
 @RunWith(MockitoJUnitRunner::class)
 class UniqueTabHistoryControllerTest {
@@ -47,7 +47,7 @@ class UniqueTabHistoryControllerTest {
         val result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
-        assertTrue(result)
+        assert(result)
         verify(mockFragNavSwitchController, never()).switchTab(any(), anyOrNull())
     }
 
@@ -74,7 +74,7 @@ class UniqueTabHistoryControllerTest {
         val result = uniqueTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
-        assertTrue(result)
+        assert(result)
         verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions))
     }
 
@@ -89,7 +89,7 @@ class UniqueTabHistoryControllerTest {
         val result = uniqueTabHistoryController.popFragments(2, mockTransactionOptions)
 
         // Then
-        assertTrue(result)
+        assert(result)
         verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions))
     }
 
@@ -120,7 +120,7 @@ class UniqueTabHistoryControllerTest {
         val result = uniqueTabHistoryController.popFragments(15, mockTransactionOptions)
 
         // Then
-        assertTrue(result)
+        assert(result)
         argumentCaptor<Int>().apply {
             verify(mockFragNavSwitchController, times(4)).switchTab(capture(), eq(mockTransactionOptions))
 
@@ -147,7 +147,7 @@ class UniqueTabHistoryControllerTest {
 
         // When
         for (i in 0..3) {
-            assertTrue(uniqueTabHistoryController.popFragments(1, mockTransactionOptions))
+            assert(uniqueTabHistoryController.popFragments(1, mockTransactionOptions))
         }
         assertFalse(uniqueTabHistoryController.popFragments(1, mockTransactionOptions))
 
@@ -176,7 +176,7 @@ class UniqueTabHistoryControllerTest {
         mockNavSwitchController(newUniqueTabHistoryController)
         newUniqueTabHistoryController.restoreFromBundle(mockBundle)
         for (i in 0..3) {
-            assertTrue(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions))
+            assert(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions))
         }
 
         // Then

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryControllerTest.kt
@@ -5,7 +5,8 @@ import com.ncapdevi.fragnav.FragNavPopController
 import com.ncapdevi.fragnav.FragNavSwitchController
 import com.ncapdevi.fragnav.FragNavTransactionOptions
 import com.nhaarman.mockitokotlin2.*
-import junit.framework.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,7 +48,7 @@ class UnlimitedTabHistoryControllerTest {
         val result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
-        assertTrue(result)
+        assert(result)
         verify(mockFragNavSwitchController, never()).switchTab(any(), anyOrNull())
     }
 
@@ -74,7 +75,7 @@ class UnlimitedTabHistoryControllerTest {
         val result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
-        assertTrue(result)
+        assert(result)
         verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions))
     }
 
@@ -89,7 +90,7 @@ class UnlimitedTabHistoryControllerTest {
         val result = unlimitedTabHistoryController.popFragments(2, mockTransactionOptions)
 
         // Then
-        assertTrue(result)
+        assert(result)
         verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions))
     }
 
@@ -118,7 +119,7 @@ class UnlimitedTabHistoryControllerTest {
         val result = unlimitedTabHistoryController.popFragments(15, mockTransactionOptions)
 
         // Then
-        assertTrue(result)
+        assert(result)
         argumentCaptor<Int>().apply {
             verify(mockFragNavSwitchController, times(9)).switchTab(capture(), eq(mockTransactionOptions))
 
@@ -148,7 +149,7 @@ class UnlimitedTabHistoryControllerTest {
 
         // When
         for (i in 0..8) {
-            assertTrue(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions))
+            assert(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions))
         }
         assertFalse(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions))
 
@@ -185,7 +186,7 @@ class UnlimitedTabHistoryControllerTest {
         mockNavSwitchController(newUniqueTabHistoryController)
         newUniqueTabHistoryController.restoreFromBundle(mockBundle)
         for (i in 0..3) {
-            assertTrue(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions))
+            assert(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions))
         }
 
         // Then

--- a/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryControllerTest.kt
+++ b/frag-nav/src/test/java/com/ncapdevi/fragnav/tabhistory/UnlimitedTabHistoryControllerTest.kt
@@ -5,8 +5,7 @@ import com.ncapdevi.fragnav.FragNavPopController
 import com.ncapdevi.fragnav.FragNavSwitchController
 import com.ncapdevi.fragnav.FragNavTransactionOptions
 import com.nhaarman.mockitokotlin2.*
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,7 +47,7 @@ class UnlimitedTabHistoryControllerTest {
         val result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
-        assert(result)
+        assertTrue(result)
         verify(mockFragNavSwitchController, never()).switchTab(any(), anyOrNull())
     }
 
@@ -75,7 +74,7 @@ class UnlimitedTabHistoryControllerTest {
         val result = unlimitedTabHistoryController.popFragments(1, mockTransactionOptions)
 
         // Then
-        assert(result)
+        assertTrue(result)
         verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions))
     }
 
@@ -90,7 +89,7 @@ class UnlimitedTabHistoryControllerTest {
         val result = unlimitedTabHistoryController.popFragments(2, mockTransactionOptions)
 
         // Then
-        assert(result)
+        assertTrue(result)
         verify(mockFragNavSwitchController, times(1)).switchTab(eq(1), eq(mockTransactionOptions))
     }
 
@@ -119,7 +118,7 @@ class UnlimitedTabHistoryControllerTest {
         val result = unlimitedTabHistoryController.popFragments(15, mockTransactionOptions)
 
         // Then
-        assert(result)
+        assertTrue(result)
         argumentCaptor<Int>().apply {
             verify(mockFragNavSwitchController, times(9)).switchTab(capture(), eq(mockTransactionOptions))
 
@@ -149,7 +148,7 @@ class UnlimitedTabHistoryControllerTest {
 
         // When
         for (i in 0..8) {
-            assert(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions))
+            assertTrue(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions))
         }
         assertFalse(unlimitedTabHistoryController.popFragments(1, mockTransactionOptions))
 
@@ -186,7 +185,7 @@ class UnlimitedTabHistoryControllerTest {
         mockNavSwitchController(newUniqueTabHistoryController)
         newUniqueTabHistoryController.restoreFromBundle(mockBundle)
         for (i in 0..3) {
-            assert(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions))
+            assertTrue(newUniqueTabHistoryController.popFragments(1, mockTransactionOptions))
         }
 
         // Then

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
+android.disableAutomaticComponentCreation=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,4 +18,6 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
+
+# https://developer.android.com/studio/releases/gradle-plugin#disable-component-creation
 android.disableAutomaticComponentCreation=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,6 @@ android.useAndroidX=true
 
 # https://developer.android.com/studio/releases/gradle-plugin#disable-component-creation
 android.disableAutomaticComponentCreation=true
+
+# https://github.com/kt3k/coveralls-gradle-plugin/issues/85
+systemProp.jdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip


### PR DESCRIPTION
### Story
There's a known issue that if you use the hiding strategy on the fragment switch, the fragment's lifecycle won't be changed.

However, there's a new [setMaxLifecycle](https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction#setMaxLifecycle(androidx.fragment.app.Fragment,androidx.lifecycle.Lifecycle.State)) function been added in the `FragmentTransaction` which can set the maximum lifecycle state during the transaction, and `ViewPager2.FragmentStateAdapter` actually has such implementation.

Bringing this function call to the library for the hiding strategy, so the fragment lifecycle will be triggered properly during switching.

### What have been changed in this PR:
- Set max lifecycle to "Started" for those fragments that are going to be hidden in the transaction.
- Updated quite a lot of dependencies
- Adjusted the gradle settings for internal publishing